### PR TITLE
Make id first argument in `param`, `new_param` etc.

### DIFF
--- a/examples/custom_computenode.cpp
+++ b/examples/custom_computenode.cpp
@@ -18,8 +18,8 @@ public:
 int main()
 {
     // just create to values
-    auto v1 = parametric::new_param(10.0, "v1");
-    auto v2 = parametric::new_param(2.0, "v2");
+    auto v1 = parametric::new_param("v1", 10.0);
+    auto v2 = parametric::new_param("v2", 2.0);
 
     // now we are creating the compute node and getting the result parameter
     auto result = parametric::compute<DivComputer>(v1, v2);

--- a/examples/parametric_struct.cpp
+++ b/examples/parametric_struct.cpp
@@ -4,8 +4,8 @@
 // This is a simple structure composed of multiple parameters
 struct AStruct
 {
-    parametric::param<int> a{10, "a"};
-    parametric::param<int> b{100, "a"};
+    parametric::param<int> a{"a", 10};
+    parametric::param<int> b{"b", 100};
 };
 
 // As a best practice, create a helper function to build parametric

--- a/examples/serialization.cpp
+++ b/examples/serialization.cpp
@@ -141,8 +141,8 @@ std::string serialize(parametric::param<MyDouble> const& p){
 
 int main()
 {
-    auto a = parametric::new_param(MyDouble{0.5}, "a");
-    auto b = parametric::new_param(MyDouble{0.1}, "b");
+    auto a = parametric::new_param("a", MyDouble{0.5});
+    auto b = parametric::new_param("b", MyDouble{0.1});
     auto c = my_eval("c", BinaryOp::plus, a, b);
     auto d = my_eval("d", BinaryOp::div, c, b);
 

--- a/parametric/core.hpp
+++ b/parametric/core.hpp
@@ -43,8 +43,8 @@ public:
      *
      * After construction, the parameter is valid (it contains a value)
      */
-    param(const T& v, const std::string& id)
-        : m_holder(std::make_shared<node_type>(v, id))
+    param(const std::string& id, const T& v)
+        : m_holder(std::make_shared<node_type>(id, v))
     {}
 
     /**
@@ -57,8 +57,8 @@ public:
     {}
 
     template <typename... Args>
-    param(std::in_place_t, Args const&... args, std::string const& id)
-        : m_holder(std::make_shared<node_type>(std::in_place_t(), args..., id))
+    param(std::string const& id, std::in_place_t, Args const&... args)
+        : m_holder(std::make_shared<node_type>(id, std::in_place_t(), args...))
     {}
 
     /// @private
@@ -183,9 +183,9 @@ private:
  * and identifier id
  */
 template <class T, typename S=DefaultSerializer>
-param<T, S> new_param(const T& v, const std::string& id)
+param<T, S> new_param(const std::string& id, const T& v)
 {
-    return param<T, S>(v, id);
+    return param<T, S>(id, v);
 }
 
 /**
@@ -194,7 +194,7 @@ param<T, S> new_param(const T& v, const std::string& id)
 template <class T, typename S=DefaultSerializer>
 param<T, S> new_param(const T& v)
 {
-    return parametric::new_param<T, S>(v, TypeName<T>::Get());
+    return parametric::new_param<T, S>(TypeName<T>::Get(), v);
 }
 
 /**
@@ -218,9 +218,9 @@ param<T, S> new_param()
  * @return param<T> the created parameter
  */
 template <typename T, typename S=DefaultSerializer, typename... Args>
-param<T, S> make_param(Args const&... args, std::string const& id){
+param<T, S> make_param(std::string const& id, Args const&... args){
     static_assert(std::is_constructible<T, Args...>::value, "make_param: T is not constructible from given arguments");
-    return parametric::param<T, S>(std::in_place_t(), args..., id);
+    return parametric::param<T, S>(id, std::in_place_t(), args...);
 }
 
 /// @private
@@ -786,7 +786,7 @@ new_parametric_struct(const T& the_struct, const parametric::param<Args, S>& ...
     struct Connector : public ComputeNode<Connector,Results, Arguments> {};
 
     auto c = std::make_shared<Connector>();
-    auto t = param<T>(the_struct, "");
+    auto t = param<T>("", the_struct);
 
     // connect c to arguments
     (add_parent(c, parametric_members.node_pointer()), ...);

--- a/parametric/impl/core_impl.hpp
+++ b/parametric/impl/core_impl.hpp
@@ -38,7 +38,7 @@ public:
     >;
     using serializer_type = S;
 
-    param_holder(const ResultType& v, const std::string& id)
+    param_holder(const std::string& id, const ResultType& v)
         : ClonableDAGNode<param_holder<ResultType, S>>(id)
     {
         if constexpr (std::is_lvalue_reference_v<ResultType>){
@@ -61,7 +61,7 @@ public:
 
     // in-place constructor
     template <typename... Args>
-    param_holder(std::in_place_t, Args const&... args, std::string const& id)
+    param_holder(std::string const& id, std::in_place_t, Args const&... args)
         : ClonableDAGNode<param_holder<ResultType, S>>(id)
         , m_value(std::in_place_t(), args...)
     {}

--- a/tests/customclass.cpp
+++ b/tests/customclass.cpp
@@ -41,7 +41,7 @@ CustomResult custom_compute(parametric::param<double> op1, double op2){
 
 TEST(CustomClass, multipleOuts)
 {
-    auto b = parametric::new_param(4.0, "b");
+    auto b = parametric::new_param("b", 4.0);
 
     auto node = custom_compute(b, 2.0);
     auto pow_result = node.pow();

--- a/tests/invalidator.cpp
+++ b/tests/invalidator.cpp
@@ -7,8 +7,8 @@
 
 struct MyParms
 {
-    parametric::param<float> a{1., "a"};
-    parametric::param<float> b{2., "b"};
+    parametric::param<float> a{"a", 1.};
+    parametric::param<float> b{"b", 2.};
 };
 
 /**

--- a/tests/param.cpp
+++ b/tests/param.cpp
@@ -69,7 +69,7 @@ TEST_F(Param, make_param){
 TEST_F(Param, new_param){
 
     {
-        auto t = parametric::new_param(Counter(), "");
+        auto t = parametric::new_param("", Counter());
     }
 
     EXPECT_EQ(m_ctor_counter, 1);

--- a/tests/parametric_struct.cpp
+++ b/tests/parametric_struct.cpp
@@ -5,8 +5,8 @@
 
 struct MyParms
 {
-    parametric::param<float> a{1., "a"};
-    parametric::param<float> b{10, "b"};
+    parametric::param<float> a{"a", 1.};
+    parametric::param<float> b{"b", 10};
     float c{100};
 };
 

--- a/tests/serialize.cpp
+++ b/tests/serialize.cpp
@@ -77,8 +77,8 @@ TEST(Serialize, CustomSerializer)
 
 TEST(Serialize, CustomComputeNode)
 {
-    auto x = parametric::new_param(Foo{"XYZ", 44.3}, "x");
-    auto y = parametric::new_param(Foo{"ABC", 1.23}, "y");
+    auto x = parametric::new_param("x", Foo{"XYZ", 44.3});
+    auto y = parametric::new_param("y", Foo{"ABC", 1.23});
     auto z = parametric::compute(std::make_shared<Bar>("z"), x, y);
 
     std::string expected = 
@@ -89,8 +89,8 @@ TEST(Serialize, CustomComputeNode)
 TEST(Serialize, RecursiveSerializer)
 {
     // create a dependency tree
-    auto a= parametric::new_param(Foo{"XYZ", 44.3}, "a");
-    auto b = parametric::new_param(Foo{"ABC", 1.23}, "b");
+    auto a= parametric::new_param("a", Foo{"XYZ", 44.3});
+    auto b = parametric::new_param("b", Foo{"ABC", 1.23});
     auto c = parametric::compute(std::make_shared<Bar>("c"), a, b);
     auto d = parametric::compute(std::make_shared<Bar>("d"), b, c);
 


### PR DESCRIPTION
Fixes #24. 

This PR makes sure that in all constructors/factory functions that create a new parameter, the id is the first argument. With this, parameter packs are at the end and no compiler should be confused as to wether the last argument is the id or the last parameter pack value.