### PR TITLE
CMake: Make unit tests and examples optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(parametric VERSION 0.3.4)
-
-option(BUILD_PARAMETRIC_BENCHMARKS "Build benchmarks using Google Benchmark" OFF)
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
@@ -16,10 +14,7 @@ target_compile_features(parametric INTERFACE cxx_std_17)
 
 include(GNUInstallDirs)
 
-if(BUILD_PARAMETRIC_BENCHMARKS)
 add_subdirectory(benchmarks)
-endif()
-
 add_subdirectory(examples)
 add_subdirectory(tests)
 add_subdirectory(docs)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,28 +1,34 @@
-project(parametric-benchmarks)
+option(BUILD_PARAMETRIC_BENCHMARKS "Build benchmarks using Google Benchmark" OFF)
+
+if(BUILD_PARAMETRIC_BENCHMARKS)
+
+    project(parametric-benchmarks)
 
 
-# download googlebenchmark as thirdparty dependency
-include(FetchContent)
-FetchContent_Declare(googlebenchmark
-        GIT_REPOSITORY https://github.com/google/benchmark.git
-        GIT_TAG "v1.5.2"
-)
-set(BENCHMARK_DOWNLOAD_DEPENDENCIES ON)
-set(BENCHMARK_ENABLE_TESTING OFF)
-FetchContent_MakeAvailable(googlebenchmark)
+    # download googlebenchmark as thirdparty dependency
+    include(FetchContent)
+    FetchContent_Declare(googlebenchmark
+            GIT_REPOSITORY https://github.com/google/benchmark.git
+            GIT_TAG "v1.5.2"
+    )
+    set(BENCHMARK_DOWNLOAD_DEPENDENCIES ON)
+    set(BENCHMARK_ENABLE_TESTING OFF)
+    FetchContent_MakeAvailable(googlebenchmark)
 
-if (NOT TARGET "parametric")
-    find_package(parametric CONFIG REQUIRED)
+    if (NOT TARGET "parametric")
+        find_package(parametric CONFIG REQUIRED)
+    endif()
+
+    set(BENCHMARKS
+        main.cpp
+        bench_operators.cpp
+    )
+
+    add_executable(benchmarks ${BENCHMARKS})
+    target_include_directories(benchmarks PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    target_link_libraries(benchmarks PRIVATE parametric benchmark::benchmark)
+    target_compile_options(benchmarks PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>: -Wall -Wextra -Wshadow --pedantic-errors -Wno-deprecated-copy>
+        $<$<CXX_COMPILER_ID:MSVC>: /W4 /WX>)
+
 endif()
-
-set(BENCHMARKS
-    main.cpp
-    bench_operators.cpp
-)
-
-add_executable(benchmarks ${BENCHMARKS})
-target_include_directories(benchmarks PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(benchmarks PRIVATE parametric benchmark::benchmark)
-target_compile_options(benchmarks PRIVATE
-    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>: -Wall -Wextra -Wshadow --pedantic-errors -Wno-deprecated-copy>
-    $<$<CXX_COMPILER_ID:MSVC>: /W4 /WX>)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,26 +1,32 @@
-cmake_minimum_required(VERSION 3.5)
+option(PARAMETRIC_BUILD_EXAMPLES "Build examples" OFF)
 
-project(parametric-examples)
+if(PARAMETRIC_BUILD_EXAMPLES)
 
-if (NOT TARGET "parametric")
-  find_package(parametric REQUIRED)
+  cmake_minimum_required(VERSION 3.10)
+
+  project(parametric-examples)
+
+  if (NOT TARGET "parametric")
+    find_package(parametric REQUIRED)
+  endif()
+
+  add_executable(tutorial tutorial.cpp)
+  add_executable(custom_computenode custom_computenode.cpp)
+  add_executable(parametric_struct parametric_struct.cpp)
+  add_executable(serialization serialization.cpp)
+  target_link_libraries(tutorial PRIVATE parametric)
+  target_link_libraries(custom_computenode PRIVATE parametric)
+  target_link_libraries(parametric_struct PRIVATE parametric)
+  target_link_libraries(serialization PRIVATE parametric)
+
+  # a CAD example
+  find_package(OCE QUIET)
+  if (OCE_FOUND)
+      add_executable(parametric_cad parametric_cad.cpp)
+      target_link_libraries(parametric_cad PRIVATE parametric TKBO TKPrim)
+      target_include_directories(parametric_cad PRIVATE ${OCE_INCLUDE_DIRS})
+  else (OCE_FOUND)
+      message(STATUS "OCE not found. Parametric CAD example cannot be build.")
+  endif(OCE_FOUND)
+
 endif()
-
-add_executable(tutorial tutorial.cpp)
-add_executable(custom_computenode custom_computenode.cpp)
-add_executable(parametric_struct parametric_struct.cpp)
-add_executable(serialization serialization.cpp)
-target_link_libraries(tutorial PRIVATE parametric)
-target_link_libraries(custom_computenode PRIVATE parametric)
-target_link_libraries(parametric_struct PRIVATE parametric)
-target_link_libraries(serialization PRIVATE parametric)
-
-# a CAD example
-find_package(OCE QUIET)
-if (OCE_FOUND)
-    add_executable(parametric_cad parametric_cad.cpp)
-    target_link_libraries(parametric_cad PRIVATE parametric TKBO TKPrim)
-    target_include_directories(parametric_cad PRIVATE ${OCE_INCLUDE_DIRS})
-else (OCE_FOUND)
-    message(STATUS "OCE not found. Parametric CAD example cannot be build.")
-endif(OCE_FOUND)

--- a/pixi.toml
+++ b/pixi.toml
@@ -32,7 +32,9 @@ configure = { cmd = [
     "-B", "build",
     "-D", "CMAKE_INSTALL_PREFIX=build/install",
     "-D", "CMAKE_BUILD_TYPE={{ config }}",
-    "-D", "PARAMETRIC_BUILD_DOCS={{ docs }}"
+    "-D", "PARAMETRIC_BUILD_DOCS={{ docs }}",
+    "-D", "PARAMETRIC_BUILD_TESTS=ON",
+    "-D", "PARAMETRIC_BUILD_EXAMPLES=ON",
 ], args = [
     { "arg" = "config", "default"="Release"},
     { "arg" = "docs", "default"="ON"}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,28 +1,33 @@
-cmake_minimum_required(VERSION 3.5)
-project(parametric-tests)
+option(PARAMETRIC_BUILD_TESTS "Build tests using Google Test" OFF)
 
-if (NOT TARGET "parametric")
-  find_package(parametric REQUIRED)
+if(PARAMETRIC_BUILD_TESTS)
+  cmake_minimum_required(VERSION 3.10)
+  project(parametric-tests)
+
+  if (NOT TARGET "parametric")
+    find_package(parametric REQUIRED)
+  endif()
+
+  enable_testing()
+  list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+
+  set(GOOGLE_TEST_INDIVIDUAL ON)
+  include(AddGoogleTest)
+
+  set(TESTSOURCES
+    testmain.cpp
+    dag.cpp
+    eval.cpp
+    customclass.cpp
+    invalidator.cpp
+    param.cpp
+    parametric_struct.cpp
+    serialize.cpp
+  )
+
+  add_executable(runUnitTests ${TESTSOURCES})
+  target_link_libraries(runUnitTests PRIVATE parametric gtest_main)
+  target_compile_features(runUnitTests PRIVATE cxx_std_17)
+  add_gtest(runUnitTests)
+
 endif()
-
-enable_testing()
-list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
-
-set(GOOGLE_TEST_INDIVIDUAL ON)
-include(AddGoogleTest)
-
-set(TESTSOURCES
-  testmain.cpp
-  dag.cpp
-  eval.cpp
-  customclass.cpp
-  invalidator.cpp
-  param.cpp
-  parametric_struct.cpp
-  serialize.cpp
-)
-
-add_executable(runUnitTests ${TESTSOURCES})
-target_link_libraries(runUnitTests PRIVATE parametric gtest_main)
-target_compile_features(runUnitTests PRIVATE cxx_std_17)
-add_gtest(runUnitTests)

--- a/tests/cmake/AddGoogleTest.cmake
+++ b/tests/cmake/AddGoogleTest.cmake
@@ -12,7 +12,7 @@ if(CMAKE_VERSION VERSION_LESS 3.11)
     include(DownloadProject)
     download_project(PROJ                googletest
 		     GIT_REPOSITORY      https://github.com/google/googletest.git
-		     GIT_TAG             release-1.12.1
+		     GIT_TAG             v1.17.0
 		     UPDATE_DISCONNECTED 1
 		     QUIET
     )
@@ -25,7 +25,7 @@ else()
     include(FetchContent)
     FetchContent_Declare(googletest
         GIT_REPOSITORY      https://github.com/google/googletest.git
-        GIT_TAG             release-1.12.1)
+        GIT_TAG             v1.17.0)
     FetchContent_GetProperties(googletest)
     if(NOT googletest_POPULATED)
         FetchContent_Populate(googletest)

--- a/tests/serialize.cpp
+++ b/tests/serialize.cpp
@@ -2,6 +2,7 @@
 
 #include <parametric/core.hpp>
 #include <sstream>
+#include <iomanip>
 
 using namespace std::string_literals;
 


### PR DESCRIPTION
Fix #58.

Also bumps the minimum cmake version and the google tests version.